### PR TITLE
Mon-768/Add-Module-Key

### DIFF
--- a/ps_monekcheckout/ps_monekcheckout.php
+++ b/ps_monekcheckout/ps_monekcheckout.php
@@ -40,7 +40,7 @@ class ps_monekcheckout extends PaymentModule
     {
         $this->name = 'ps_monekcheckout';
         $this->tab = 'payments_gateways';
-        $this->version = '1.0.0';
+        $this->version = '1.0.1';
         $this->author = 'monek';
         $this->controllers = ['validation'];
         $this->is_eu_compatible = 1;

--- a/ps_monekcheckout/ps_monekcheckout.php
+++ b/ps_monekcheckout/ps_monekcheckout.php
@@ -45,6 +45,7 @@ class ps_monekcheckout extends PaymentModule
         $this->controllers = ['validation'];
         $this->is_eu_compatible = 1;
 
+        $this->module_key = 'c1614c239af92968e5fae97f366e9961';
         $this->ps_versions_compliancy = ['min' => '1.7', 'max' => _PS_VERSION_];
         $this->bootstrap = true;
 


### PR DESCRIPTION
Prestashop have now provided me with a module key for our product, this needs to be included so that future updates will be recognised by users who have our app installed. 