### PR TITLE
MON-967/Add-GooglePay-Config

### DIFF
--- a/monekcheckout/Readme.md
+++ b/monekcheckout/Readme.md
@@ -46,7 +46,15 @@ Save changes to apply the configuration.
 If you don't have the necessary information, such as your Monek ID, visit [Monek Contact Page](https://monek.com/contact) to get help. Ensure that all information entered is accurate to enable seamless payment processing on your WooCommerce store.
 
 
+## Configuration
 
+### GooglePay: 
+
+Indicates if the Google Pay™ button will appear on the checkout page. `YES` or `NO` (default)
+
+All merchants must adhere to the Google Pay APIs [Acceptable Use Policy](https://payments.developers.google.com/terms/aup) and accept the terms defined in the [Google Pay API Terms of Service](https://payments.developers.google.com/terms/sellertos). 
+
+Google Pay is a trademark of Google LLC.
 
 
 ## Known Issues:

--- a/monekcheckout/changelog.md
+++ b/monekcheckout/changelog.md
@@ -1,6 +1,9 @@
 # Monek.Checkout.PrestaShop
 ### Monek Checkout Changelog
 
+#### September 10 2024 - version 1.1.0
+* Added - Added a new feature to allow the user to enable GooglePay as a payment method
+
 #### September 05 2024 - Version 1.0.5
 * Fixed - Validating declined orders.
 

--- a/monekcheckout/controllers/front/helpers/cart_converter.php
+++ b/monekcheckout/controllers/front/helpers/cart_converter.php
@@ -297,7 +297,7 @@ class CartConverter
      * @return array
 	 */
     public function prepare_payment_request_body_data(Context $context, Cart $cart, string $merchant_id, string $country_code, 
-        string $return_plugin_url, string $webhook_url, string $purchase_description) : array
+        string $return_plugin_url, string $webhook_url, string $purchase_description, bool $enableGooglePay) : array
     {
         $billing_amount = $cart->getOrderTotal(true, Cart::BOTH);
 
@@ -331,7 +331,8 @@ class CartConverter
             'PurchaseDescription' => $purchase_description,
             'IntegritySecret' => $integrity_secret,
             'Basket' => $this->generate_basket_base64($cart),
-            'ShowDeliveryAddress' => 'YES',
+            'ShowDeliveryAddress' => 'YES',            
+            'ShowGooglePay' => $enableGooglePay ? 'YES' : 'NO',
         ];
 
         $body_data = $this->generate_cardholder_detail_information($context, $body_data);

--- a/monekcheckout/controllers/front/validation.php
+++ b/monekcheckout/controllers/front/validation.php
@@ -61,6 +61,7 @@ class monekcheckoutValidationModuleFrontController extends ModuleFrontController
             $basketSummary = pSQL(Configuration::get('MONEKCHECKOUT_BASKET_SUMMARY'));
             $returnUrl = filter_var($this->context->link->getModuleLink($this->module->name, 'return', [], true), FILTER_SANITIZE_URL);
             $webhookUrl = filter_var($this->context->link->getModuleLink($this->module->name, 'webhook', [], true), FILTER_SANITIZE_URL);
+            $enableGooglePay = pSQL(Configuration::get('MONEKCHECKOUT_GOOGLE_PAY'));
 
             $bodyData = $cartConverter->prepare_payment_request_body_data(
                 $this->context,
@@ -70,6 +71,7 @@ class monekcheckoutValidationModuleFrontController extends ModuleFrontController
                 $returnUrl,
                 $webhookUrl,
                 $basketSummary,
+                $enableGooglePay
             );
 
             $this->sendPaymentRequest($bodyData);

--- a/monekcheckout/monekcheckout.php
+++ b/monekcheckout/monekcheckout.php
@@ -37,6 +37,7 @@ class monekcheckout extends PaymentModule
 {
     public const CONFIG_BASKET_SUMMARY = 'MONEKCHECKOUT_BASKET_SUMMARY';
     public const CONFIG_COUNTRY = 'MONEKCHECKOUT_COUNTRY';
+    public const CONFIG_GOOGLE_PAY = 'MONEKCHECKOUT_GOOGLE_PAY';
     public const CONFIG_MONEK_ID = 'MONEKCHECKOUT_MONEK_ID';
     public const CONFIG_TEST_MODE = 'MONEKCHECKOUT_TEST_MODE';
     public const AWAITING_ORDER_CONFIRMATION_STATE_ID = 'AWAITING_ORDER_CONFIRMATION_STATE_ID';
@@ -45,7 +46,7 @@ class monekcheckout extends PaymentModule
     {
         $this->name = 'monekcheckout';
         $this->tab = 'payments_gateways';
-        $this->version = '1.0.5';
+        $this->version = '1.1.0';
         $this->author = 'monek';
         $this->controllers = ['validation'];
         $this->is_eu_compatible = 1;
@@ -98,7 +99,8 @@ class monekcheckout extends PaymentModule
             && Configuration::updateValue(self::CONFIG_BASKET_SUMMARY, 'Goods')
             && Configuration::updateValue(self::CONFIG_COUNTRY, 'GB')
             && Configuration::updateValue(self::CONFIG_MONEK_ID, '')
-            && Configuration::updateValue(self::CONFIG_TEST_MODE, '');
+            && Configuration::updateValue(self::CONFIG_TEST_MODE, '')
+            && Configuration::updateValue(self::CONFIG_GOOGLE_PAY, '');
     }
 
     /**
@@ -112,7 +114,8 @@ class monekcheckout extends PaymentModule
             && Configuration::deleteByName(self::CONFIG_BASKET_SUMMARY)
             && Configuration::deleteByName(self::CONFIG_COUNTRY)
             && Configuration::deleteByName(self::CONFIG_MONEK_ID)
-            && Configuration::deleteByName(self::CONFIG_TEST_MODE);
+            && Configuration::deleteByName(self::CONFIG_TEST_MODE)
+            && Configuration::deleteByName(self::CONFIG_GOOGLE_PAY);
     }
 
     /**
@@ -161,6 +164,7 @@ class monekcheckout extends PaymentModule
             $country = pSQL(Tools::getValue(self::CONFIG_COUNTRY));
             $monekid = pSQL(trim(Tools::getValue(self::CONFIG_MONEK_ID)));
             $testMode = Tools::getValue(self::CONFIG_TEST_MODE);
+            $googlePayEnabled = Tools::getValue(self::CONFIG_GOOGLE_PAY);
 
             if (empty($monekid)) {
                 $output .= $this->displayError($this->l('Invalid Monek ID'));
@@ -173,6 +177,7 @@ class monekcheckout extends PaymentModule
                 Configuration::updateValue(self::CONFIG_COUNTRY, $country);
                 Configuration::updateValue(self::CONFIG_MONEK_ID, $monekid);
                 Configuration::updateValue(self::CONFIG_TEST_MODE, $testMode);
+                Configuration::updateValue(self::CONFIG_GOOGLE_PAY, $googlePayEnabled);
                 $output .= $this->displayConfirmation($this->l('Settings updated'));
             }
         }
@@ -231,6 +236,25 @@ class monekcheckout extends PaymentModule
                         ],
                     ],
                     [
+                        'type' => 'switch',
+                        'label' => $this->l('Enable GooglePay'),
+                        'name' => self::CONFIG_GOOGLE_PAY,
+                        'is_bool' => true,
+                        'values' => [
+                            [
+                                'id' => self::CONFIG_GOOGLE_PAY . '_on',
+                                'value' => true,
+                                'label' => $this->l('Enabled'),
+                            ],
+                            [
+                                'id' => self::CONFIG_GOOGLE_PAY . '_off',
+                                'value' => false,
+                                'label' => $this->l('Disabled'),
+                            ],
+                        ],
+                        'desc' => $this->l('Enable this option to provide access to GooglePay as a payment option. Merchants must adhere to the Google Pay APIs Acceptable Use Policy and accept the terms defined in the Google Pay API Terms of Service.'),
+                    ],
+                    [
                         'type' => 'text',
                         'label' => $this->l('Basket Summary'),
                         'name' => self::CONFIG_BASKET_SUMMARY,
@@ -277,6 +301,7 @@ class monekcheckout extends PaymentModule
             self::CONFIG_COUNTRY => Tools::getValue(self::CONFIG_COUNTRY, Configuration::get(self::CONFIG_COUNTRY)),
             self::CONFIG_MONEK_ID => Tools::getValue(self::CONFIG_MONEK_ID, Configuration::get(self::CONFIG_MONEK_ID)),
             self::CONFIG_TEST_MODE => Tools::getValue(self::CONFIG_TEST_MODE, Configuration::get(self::CONFIG_TEST_MODE)),
+            self::CONFIG_GOOGLE_PAY => Tools::getValue(self::CONFIG_GOOGLE_PAY, Configuration::get(self::CONFIG_GOOGLE_PAY)),
         ];
     }
 


### PR DESCRIPTION
### Google Pay Setting Added to PrestaShop Plugin

We have added a new setting to the **PrestaShop Plugin** page that allows merchants to enable Google Pay as a checkout option. The default value for this setting is set to `false`.

Key details:
- **Clear communication**: We provide visible instructions on the page, ensuring merchants are instructed to look into the terms and conditions they are agreeing to when enabling Google Pay.
- **Default setting**: The Google Pay option is disabled by default (`false`).
- **Configuration behavior**: When this setting is enabled (`true`), the `ShowGooglePay` configuration will be sent with a `YES` value.

This update ensures merchants have clear control over the Google Pay integration and are informed of all related conditions before activation.


![image](https://github.com/user-attachments/assets/81784bb5-788e-496f-a6a3-39a557e986ab)
